### PR TITLE
Avoid printing not-found message on non-tty stdout

### DIFF
--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -78,10 +78,7 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if len(sponsors) == 0 {
-		if opts.IO.IsStdoutTTY() {
-			fmt.Fprintln(opts.IO.Out, "no sponsor found")
-		}
-		return nil
+		return cmdutil.NewNoResultsError("no sponsor found")
 	}
 
 	headers := []string{"Sponsor"}

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/shurcooL/graphql"
+	"github.com/shurcooL/githubv4"
 	"github.com/spf13/cobra"
 
 	"github.com/cli/cli/v2/api"
@@ -106,10 +106,10 @@ func listSponsors(httpClient *http.Client, hostname string, username string, lim
 				Edges []struct {
 					Node struct {
 						User struct {
-							Login graphql.String
+							Login githubv4.String
 						} `graphql:"... on User"`
 						Org struct {
-							Login graphql.String
+							Login githubv4.String
 						} `graphql:"... on Organization"`
 					}
 				}
@@ -120,8 +120,8 @@ func listSponsors(httpClient *http.Client, hostname string, username string, lim
 	client := api.NewClientFromHTTP(httpClient)
 
 	variables := map[string]any{
-		"login": graphql.String(username),
-		"limit": graphql.Int(limit),
+		"login": githubv4.String(username),
+		"limit": githubv4.Int(limit),
 	}
 
 	err := client.Query(hostname, "UserSponsorList", &query, variables)

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -78,7 +78,8 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if len(sponsors) == 0 {
-		return cmdutil.NewNoResultsError("no sponsor found")
+		fmt.Fprintln(opts.IO.Out, "no sponsor found")
+		return nil
 	}
 
 	headers := []string{"Sponsor"}

--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -78,7 +78,9 @@ func listRun(opts *ListOptions) error {
 	}
 
 	if len(sponsors) == 0 {
-		fmt.Fprintln(opts.IO.Out, "no sponsor found")
+		if opts.IO.IsStdoutTTY() {
+			fmt.Fprintln(opts.IO.Out, "no sponsor found")
+		}
 		return nil
 	}
 

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -123,6 +123,47 @@ func Test_listRun(t *testing.T) {
 				"bar",
 			},
 		}, {
+			name: "normal no-tty",
+			tty:  false,
+			opts: &ListOptions{
+				Username: "johndoe",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(`
+						{
+							"data": {
+								"user": {
+									"sponsors": {
+										"edges": [
+											{
+												"node": {
+													"login": "foo"
+												}
+											},
+											{
+												"node": {
+													"login": "bar"
+												}
+											}
+										]
+									}
+								}
+							}
+						}`,
+						func(_ string, inputs map[string]interface{}) {
+							assert.Equal(t, "johndoe", inputs["login"])
+							assert.Equal(t, float64(30), inputs["limit"])
+						},
+					),
+				)
+			},
+			wantStdout: []string{
+				"foo",
+				"bar",
+			},
+		}, {
 			name: "normal tty, no sponsor",
 			tty:  true,
 			opts: &ListOptions{
@@ -149,6 +190,32 @@ func Test_listRun(t *testing.T) {
 				)
 			},
 			wantStdout: []string{"no sponsor found"},
+		}, {
+			name: "normal no-tty, no sponsor",
+			tty:  false,
+			opts: &ListOptions{
+				Username: "johndoe",
+			},
+			httpStubs: func(reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(`
+						{
+							"data": {
+								"user": {
+									"sponsors": {
+										"edges": []
+									}
+								}
+							}
+						}`,
+						func(_ string, inputs map[string]interface{}) {
+							assert.Equal(t, "johndoe", inputs["login"])
+							assert.Equal(t, float64(30), inputs["limit"])
+						},
+					),
+				)
+			},
 		}, {
 			name: "api error",
 			tty:  true,

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -148,7 +148,7 @@ func Test_listRun(t *testing.T) {
 					),
 				)
 			},
-			wantStderr: "no sponsor found\n",
+			wantStdout: []string{"no sponsor found"},
 		}, {
 			name: "api error",
 			tty:  true,

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -77,7 +77,6 @@ func Test_listRun(t *testing.T) {
 		opts       *ListOptions
 		httpStubs  func(*httpmock.Registry)
 		wantStdout []string
-		wantStderr string
 		wantErr    string
 	}{
 		{
@@ -240,7 +239,7 @@ func Test_listRun(t *testing.T) {
 			reg := &httpmock.Registry{}
 			defer reg.Verify(t)
 
-			ios, _, stdout, stderr := iostreams.Test()
+			ios, _, stdout, _ := iostreams.Test()
 
 			ios.SetStdoutTTY(tt.tty)
 
@@ -266,7 +265,6 @@ func Test_listRun(t *testing.T) {
 				expectedStdout = fmt.Sprintf("%s\n", strings.Join(tt.wantStdout, "\n"))
 			}
 			assert.Equal(t, expectedStdout, stdout.String())
-			assert.Equal(t, tt.wantStderr, stderr.String())
 		})
 	}
 }

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -188,7 +188,7 @@ func Test_listRun(t *testing.T) {
 					),
 				)
 			},
-			wantStdout: []string{"no sponsor found"},
+			wantErr: "no sponsor found",
 		}, {
 			name: "normal no-tty, no sponsor",
 			tty:  false,
@@ -215,6 +215,7 @@ func Test_listRun(t *testing.T) {
 					),
 				)
 			},
+			wantErr: "no sponsor found",
 		}, {
 			name: "api error",
 			tty:  true,


### PR DESCRIPTION
This PR changes the way the not-found message is printed. Before this, it was printed on stdout. Now the message is printed to stdout, only if it's a tty stream.

## Acceptance criteria

**Given** I have the name of a Sponsorable user that has no sponsors
**When** I run gh sponsors list <user> | cat
**Then** I see no output at all

Implementation result:

```sh
$ gh sponsors list babakks | cat
$
```
