### PR TITLE
Prompt for username in `sponsors list` command

### DIFF
--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/cli/cli/v2/api"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/internal/tableprinter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -21,6 +23,7 @@ type ListOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
 	Config     func() (gh.Config, error)
+	Prompter   prompter.Prompter
 
 	Username string
 }
@@ -30,20 +33,20 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		IO:         f.IOStreams,
 		Config:     f.Config,
 		HttpClient: f.HttpClient,
+		Prompter:   f.Prompter,
 	}
 
 	cmd := &cobra.Command{
-		Use:   "list <user>",
+		Use:   "list [<user>]",
 		Short: "List sponsors",
 		Long: heredoc.Doc(`
 			List sponsors of a given user.
 		`),
 		Aliases: []string{"ls"},
-		Args:    cmdutil.ExactArgs(1, "must specify username"),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// This is for consistency with the other commands, but the check seems
-			// irrelevant since we have already used the cobra.ExactArgs.
-			if len(args) > 0 {
+			if len(args) > 1 {
+				return cmdutil.FlagErrorf("too many arguments")
+			} else if len(args) == 1 {
 				opts.Username = args[0]
 			}
 
@@ -70,6 +73,17 @@ func listRun(opts *ListOptions) error {
 	}
 
 	username := opts.Username
+
+	if username == "" {
+		if !opts.IO.CanPrompt() {
+			return errors.New("username not provided")
+		}
+		value, err := opts.Prompter.Input("Which user do you want to target?", "")
+		if err != nil {
+			return err
+		}
+		username = value
+	}
 
 	hostname, _ := cfg.Authentication().DefaultHost()
 	sponsors, err := listSponsors(client, hostname, username, defaultListLimit)

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/cli/cli/v2/internal/config"
 	"github.com/cli/cli/v2/internal/gh"
+	"github.com/cli/cli/v2/internal/prompter"
 	"github.com/cli/cli/v2/pkg/cmdutil"
 	"github.com/cli/cli/v2/pkg/httpmock"
 	"github.com/cli/cli/v2/pkg/iostreams"
@@ -25,9 +27,11 @@ func TestNewCmdList(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "no arg",
-			cli:     "",
-			wantErr: "must specify username",
+			name: "no arg",
+			cli:  "",
+			wants: ListOptions{
+				Username: "",
+			},
 		},
 		{
 			name: "normal",
@@ -72,12 +76,13 @@ func TestNewCmdList(t *testing.T) {
 
 func Test_listRun(t *testing.T) {
 	tests := []struct {
-		name       string
-		tty        bool
-		opts       *ListOptions
-		httpStubs  func(*testing.T, *httpmock.Registry)
-		wantStdout []string
-		wantErr    string
+		name          string
+		tty           bool
+		opts          *ListOptions
+		httpStubs     func(*testing.T, *httpmock.Registry)
+		prompterStubs func(*testing.T, *prompter.PrompterMock)
+		wantStdout    []string
+		wantErr       string
 	}{
 		{
 			name: "normal tty",
@@ -115,6 +120,53 @@ func Test_listRun(t *testing.T) {
 						},
 					),
 				)
+			},
+			wantStdout: []string{
+				"SPONSOR",
+				"foo",
+				"bar",
+			},
+		}, {
+			name: "normal tty, no-username",
+			tty:  true,
+			opts: &ListOptions{},
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
+				reg.Register(
+					httpmock.GraphQL(`query UserSponsorList\b`),
+					httpmock.GraphQLQuery(`
+						{
+							"data": {
+								"user": {
+									"sponsors": {
+										"edges": [
+											{
+												"node": {
+													"login": "foo"
+												}
+											},
+											{
+												"node": {
+													"login": "bar"
+												}
+											}
+										]
+									}
+								}
+							}
+						}`,
+						func(_ string, inputs map[string]interface{}) {
+							assert.Equal(t, "johndoe", inputs["login"])
+							assert.Equal(t, float64(30), inputs["limit"])
+						},
+					),
+				)
+			},
+			prompterStubs: func(t *testing.T, pm *prompter.PrompterMock) {
+				pm.InputFunc = func(message, def string) (string, error) {
+					assert.Equal(t, "Which user do you want to target?", message)
+					assert.Empty(t, def)
+					return "johndoe", nil
+				}
 			},
 			wantStdout: []string{
 				"SPONSOR",
@@ -162,6 +214,21 @@ func Test_listRun(t *testing.T) {
 				"foo",
 				"bar",
 			},
+		}, {
+			name: "failure tty, prompt error",
+			tty:  true,
+			opts: &ListOptions{},
+			prompterStubs: func(t *testing.T, pm *prompter.PrompterMock) {
+				pm.InputFunc = func(message, def string) (string, error) {
+					return "", errors.New("prompt error")
+				}
+			},
+			wantErr: "prompt error",
+		}, {
+			name:    "failure no-tty, no-username",
+			tty:     false,
+			opts:    &ListOptions{},
+			wantErr: "username not provided",
 		}, {
 			name: "normal tty, no sponsor",
 			tty:  true,
@@ -240,8 +307,15 @@ func Test_listRun(t *testing.T) {
 			reg := &httpmock.Registry{}
 			defer reg.Verify(t)
 
+			pm := &prompter.PrompterMock{}
+			if tt.prompterStubs != nil {
+				tt.prompterStubs(t, pm)
+			}
+			tt.opts.Prompter = pm
+
 			ios, _, stdout, _ := iostreams.Test()
 
+			ios.SetStdinTTY(tt.tty)
 			ios.SetStdoutTTY(tt.tty)
 
 			tt.opts.IO = ios
@@ -252,7 +326,9 @@ func Test_listRun(t *testing.T) {
 				return config.NewBlankConfig(), nil
 			}
 
-			tt.httpStubs(t, reg)
+			if tt.httpStubs != nil {
+				tt.httpStubs(t, reg)
+			}
 
 			err := listRun(tt.opts)
 			if tt.wantErr != "" {

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -75,7 +75,7 @@ func Test_listRun(t *testing.T) {
 		name       string
 		tty        bool
 		opts       *ListOptions
-		httpStubs  func(*httpmock.Registry)
+		httpStubs  func(*testing.T, *httpmock.Registry)
 		wantStdout []string
 		wantErr    string
 	}{
@@ -85,7 +85,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(`
@@ -127,7 +127,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(`
@@ -168,7 +168,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(`
@@ -195,7 +195,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(`
@@ -222,7 +222,7 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(reg *httpmock.Registry) {
+			httpStubs: func(_ *testing.T, reg *httpmock.Registry) {
 				reg.Register(
 					httpmock.GraphQL(`query UserSponsorList\b`),
 					httpmock.GraphQLQuery(
@@ -252,7 +252,7 @@ func Test_listRun(t *testing.T) {
 				return config.NewBlankConfig(), nil
 			}
 
-			tt.httpStubs(reg)
+			tt.httpStubs(t, reg)
 
 			err := listRun(tt.opts)
 			if tt.wantErr != "" {

--- a/pkg/cmd/sponsors/sponsors.go
+++ b/pkg/cmd/sponsors/sponsors.go
@@ -1,4 +1,4 @@
-package sponsorsß
+package sponsors
 
 import (
 	cmdList "github.com/cli/cli/v2/pkg/cmd/sponsors/list"


### PR DESCRIPTION
This PR improves the `sponsors list` command by prompting for the username, if it was not provided. If it's a non-TTY stream, then an error will be returned.

## Acceptance criteria

### 1. Prompt for username (TTY)

**Given** I have the name of a Sponsorable user that has less than 30 sponsors
**When** I run gh sponsors list
**Then** I am prompted for a user e.g

```sh
➜  gh sponsors list
? Which user do you want to target? ...
```

**And** When I enter the name of the sponsorable user and press enter
**Then** I see a list of usernames in a single column table with a header

Implementation result:

```sh
$ gh sponsors list
? Which user do you want to target? onsi
SPONSOR      
austince
authzed
belden
erdnas
ibrasho
mercedes-benz
mrkmcknz
ppeble
srevinsaju
williammartin
```

### 2. Fail if username is not provided (non-TTY)

**When** I run GH_PROMPT_DISABLED=true gh sponsors list
**Then** I receive an error that no user was provided

Implementation result:

```sh
% GH_PROMPT_DISABLED=true gh sponsors list
username not provided
exit status 1
```