### PR TITLE
Add `--json` option to `sponsors list`

### DIFF
--- a/pkg/cmd/sponsors/list/list.go
+++ b/pkg/cmd/sponsors/list/list.go
@@ -19,11 +19,18 @@ import (
 
 const defaultListLimit = 30
 
+var listFields = []string{
+	"login",
+	"name",
+}
+
 type ListOptions struct {
 	HttpClient func() (*http.Client, error)
 	IO         *iostreams.IOStreams
 	Config     func() (gh.Config, error)
 	Prompter   prompter.Prompter
+
+	Exporter cmdutil.Exporter
 
 	Username string
 }
@@ -58,6 +65,8 @@ func NewCmdList(f *cmdutil.Factory, runF func(*ListOptions) error) *cobra.Comman
 		},
 	}
 
+	cmdutil.AddJSONFlags(cmd, &opts.Exporter, listFields)
+
 	return cmd
 }
 
@@ -91,6 +100,10 @@ func listRun(opts *ListOptions) error {
 		return err
 	}
 
+	if opts.Exporter != nil {
+		return opts.Exporter.Write(opts.IO, sponsors)
+	}
+
 	if len(sponsors) == 0 {
 		return cmdutil.NewNoResultsError("no sponsor found")
 	}
@@ -98,7 +111,7 @@ func listRun(opts *ListOptions) error {
 	headers := []string{"Sponsor"}
 	table := tableprinter.New(opts.IO, tableprinter.WithHeader(headers...))
 	for _, sponsor := range sponsors {
-		table.AddField(sponsor)
+		table.AddField(sponsor.Login)
 		table.EndRow()
 	}
 
@@ -110,7 +123,16 @@ func listRun(opts *ListOptions) error {
 	return nil
 }
 
-func listSponsors(httpClient *http.Client, hostname string, username string, limit uint) ([]string, error) {
+type sponsor struct {
+	Login string
+	Name  string
+}
+
+func (s sponsor) ExportData(fields []string) map[string]interface{} {
+	return cmdutil.StructExportData(s, fields)
+}
+
+func listSponsors(httpClient *http.Client, hostname string, username string, limit uint) ([]sponsor, error) {
 	var query struct {
 		User struct {
 			Sponsors struct {
@@ -118,9 +140,11 @@ func listSponsors(httpClient *http.Client, hostname string, username string, lim
 					Node struct {
 						User struct {
 							Login githubv4.String
+							Name  githubv4.String
 						} `graphql:"... on User"`
 						Org struct {
 							Login githubv4.String
+							Name  githubv4.String
 						} `graphql:"... on Organization"`
 					}
 				}
@@ -140,12 +164,18 @@ func listSponsors(httpClient *http.Client, hostname string, username string, lim
 		return nil, err
 	}
 
-	result := make([]string, 0, len(query.User.Sponsors.Edges))
+	result := make([]sponsor, 0, len(query.User.Sponsors.Edges))
 	for _, edge := range query.User.Sponsors.Edges {
 		if edge.Node.User.Login != "" {
-			result = append(result, string(edge.Node.User.Login))
+			result = append(result, sponsor{
+				Login: string(edge.Node.User.Login),
+				Name:  string(edge.Node.User.Name),
+			})
 		} else if edge.Node.Org.Login != "" {
-			result = append(result, string(edge.Node.Org.Login))
+			result = append(result, sponsor{
+				Login: string(edge.Node.Org.Login),
+				Name:  string(edge.Node.Org.Name),
+			})
 		}
 	}
 	return result, nil

--- a/pkg/cmd/sponsors/list/list_test.go
+++ b/pkg/cmd/sponsors/list/list_test.go
@@ -39,6 +39,16 @@ func TestNewCmdList(t *testing.T) {
 			wants: ListOptions{
 				Username: "johndoe",
 			},
+		}, {
+			name: "normal json",
+			cli:  "--json name,login johndoe",
+			wants: ListOptions{
+				Username: "johndoe",
+			},
+		}, {
+			name:    "failure json",
+			cli:     "--json blah johndoe",
+			wantErr: "Unknown JSON field: \"blah\"\nAvailable fields:\n  login\n  name",
 		},
 	}
 
@@ -75,6 +85,61 @@ func TestNewCmdList(t *testing.T) {
 }
 
 func Test_listRun(t *testing.T) {
+	defaultHTTPStubs := func(t *testing.T, reg *httpmock.Registry) {
+		reg.Register(
+			httpmock.GraphQL(`query UserSponsorList\b`),
+			httpmock.GraphQLQuery(`
+				{
+					"data": {
+						"user": {
+							"sponsors": {
+								"edges": [
+									{
+										"node": {
+											"login": "foo",
+											"name": "Foo"
+										}
+									},
+									{
+										"node": {
+											"login": "bar",
+											"name": "Bar"
+										}
+									}
+								]
+							}
+						}
+					}
+				}`,
+				func(_ string, inputs map[string]interface{}) {
+					assert.Equal(t, "johndoe", inputs["login"])
+					assert.Equal(t, float64(30), inputs["limit"])
+				},
+			),
+		)
+	}
+
+	emptyRespHTTPStubs := func(t *testing.T, reg *httpmock.Registry) {
+		reg.Register(
+			httpmock.GraphQL(`query UserSponsorList\b`),
+			httpmock.GraphQLQuery(`
+				{
+					"data": {
+						"user": {
+							"sponsors": {
+								"edges": []
+							}
+						}
+					}
+				}`,
+				func(_ string, inputs map[string]interface{}) {
+					assert.Equal(t, "johndoe", inputs["login"])
+					assert.Equal(t, float64(30), inputs["limit"])
+				},
+			),
+		)
+	}
+
 	tests := []struct {
 		name          string
 		tty           bool
@@ -90,77 +155,17 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query UserSponsorList\b`),
-					httpmock.GraphQLQuery(`
-						{
-							"data": {
-								"user": {
-									"sponsors": {
-										"edges": [
-											{
-												"node": {
-													"login": "foo"
-												}
-											},
-											{
-												"node": {
-													"login": "bar"
-												}
-											}
-										]
-									}
-								}
-							}
-						}`,
-						func(_ string, inputs map[string]interface{}) {
-							assert.Equal(t, "johndoe", inputs["login"])
-							assert.Equal(t, float64(30), inputs["limit"])
-						},
-					),
-				)
-			},
+			httpStubs: defaultHTTPStubs,
 			wantStdout: []string{
 				"SPONSOR",
 				"foo",
 				"bar",
 			},
 		}, {
-			name: "normal tty, no-username",
-			tty:  true,
-			opts: &ListOptions{},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query UserSponsorList\b`),
-					httpmock.GraphQLQuery(`
-						{
-							"data": {
-								"user": {
-									"sponsors": {
-										"edges": [
-											{
-												"node": {
-													"login": "foo"
-												}
-											},
-											{
-												"node": {
-													"login": "bar"
-												}
-											}
-										]
-									}
-								}
-							}
-						}`,
-						func(_ string, inputs map[string]interface{}) {
-							assert.Equal(t, "johndoe", inputs["login"])
-							assert.Equal(t, float64(30), inputs["limit"])
-						},
-					),
-				)
-			},
+			name:      "normal tty, no-username",
+			tty:       true,
+			opts:      &ListOptions{},
+			httpStubs: defaultHTTPStubs,
 			prompterStubs: func(t *testing.T, pm *prompter.PrompterMock) {
 				pm.InputFunc = func(message, def string) (string, error) {
 					assert.Equal(t, "Which user do you want to target?", message)
@@ -179,41 +184,37 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query UserSponsorList\b`),
-					httpmock.GraphQLQuery(`
-						{
-							"data": {
-								"user": {
-									"sponsors": {
-										"edges": [
-											{
-												"node": {
-													"login": "foo"
-												}
-											},
-											{
-												"node": {
-													"login": "bar"
-												}
-											}
-										]
-									}
-								}
-							}
-						}`,
-						func(_ string, inputs map[string]interface{}) {
-							assert.Equal(t, "johndoe", inputs["login"])
-							assert.Equal(t, float64(30), inputs["limit"])
-						},
-					),
-				)
-			},
+			httpStubs: defaultHTTPStubs,
 			wantStdout: []string{
 				"foo",
 				"bar",
 			},
+		}, {
+			name: "normal json",
+			tty:  false,
+			opts: &ListOptions{
+				Username: "johndoe",
+				Exporter: func() cmdutil.Exporter {
+					exporter := cmdutil.NewJSONExporter()
+					exporter.SetFields([]string{"login"})
+					return exporter
+				}(),
+			},
+			httpStubs:  defaultHTTPStubs,
+			wantStdout: []string{"[{\"login\":\"foo\"},{\"login\":\"bar\"}]"},
+		}, {
+			name: "normal json all fields",
+			tty:  false,
+			opts: &ListOptions{
+				Username: "johndoe",
+				Exporter: func() cmdutil.Exporter {
+					exporter := cmdutil.NewJSONExporter()
+					exporter.SetFields(listFields)
+					return exporter
+				}(),
+			},
+			httpStubs:  defaultHTTPStubs,
+			wantStdout: []string{"[{\"login\":\"foo\",\"name\":\"Foo\"},{\"login\":\"bar\",\"name\":\"Bar\"}]"},
 		}, {
 			name: "failure tty, prompt error",
 			tty:  true,
@@ -235,54 +236,16 @@ func Test_listRun(t *testing.T) {
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query UserSponsorList\b`),
-					httpmock.GraphQLQuery(`
-						{
-							"data": {
-								"user": {
-									"sponsors": {
-										"edges": []
-									}
-								}
-							}
-						}`,
-						func(_ string, inputs map[string]interface{}) {
-							assert.Equal(t, "johndoe", inputs["login"])
-							assert.Equal(t, float64(30), inputs["limit"])
-						},
-					),
-				)
-			},
-			wantErr: "no sponsor found",
+			httpStubs: emptyRespHTTPStubs,
+			wantErr:   "no sponsor found",
 		}, {
 			name: "normal no-tty, no sponsor",
 			tty:  false,
 			opts: &ListOptions{
 				Username: "johndoe",
 			},
-			httpStubs: func(t *testing.T, reg *httpmock.Registry) {
-				reg.Register(
-					httpmock.GraphQL(`query UserSponsorList\b`),
-					httpmock.GraphQLQuery(`
-						{
-							"data": {
-								"user": {
-									"sponsors": {
-										"edges": []
-									}
-								}
-							}
-						}`,
-						func(_ string, inputs map[string]interface{}) {
-							assert.Equal(t, "johndoe", inputs["login"])
-							assert.Equal(t, float64(30), inputs["limit"])
-						},
-					),
-				)
-			},
-			wantErr: "no sponsor found",
+			httpStubs: emptyRespHTTPStubs,
+			wantErr:   "no sponsor found",
 		}, {
 			name: "api error",
 			tty:  true,


### PR DESCRIPTION
This PR adds the `--json` option to the `sponsors list` command.

## Acceptance criteria

**Given** I have the name of a Sponsorable user that has less than 30 sponsors
**When** I run gh sponsors list <user> --json login
**Then** I see a JSON array of login names

Implementation result:

```sh
$ gh sponsors list onsi --json login,name
[
  {
    "login": "austince",
    "name": "Austin Cawley-Edwards"
  },
  {
    "login": "authzed",
    "name": "authzed"
  },
  ...
]
```

And if there is no sponsor for the user:

```sh
$ gh sponsors list babakks --json login,name
[]
```